### PR TITLE
Optimise style combinations and string building

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,19 +21,18 @@ linters:
     - lll # Auto formatters do this and what they can't do I don't care about
     - maintidx # This is just the inverse of complexity... which is cyclop
     - nestif # cyclop does this
+    - nlreturn # Similar to wsl, I think best left to judgement
     - nonamedreturns # Named returns are often helpful, it's naked returns that are the issue
-    - paralleltest # I've never had Go tests take longer than a few seconds, it's fine
+    - thelper # Lots of false positives due to the way I do table tests in here
     - varnamelen # Lots of false positives of things that are fine
     - wrapcheck # Not every error must be wrapped
+    - wsl # Very aggressive, some of this I like but tend to do anyway
 
 issues:
   exclude-rules:
     - path: _test\.go
       linters:
         - prealloc # These kinds of optimisations will make no difference to test code
-
-  exclude-dirs:
-    - tabwriter # This is 99% a fork of text/tabwriter
 
 linters-settings:
   cyclop:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - nestif # cyclop does this
     - nlreturn # Similar to wsl, I think best left to judgement
     - nonamedreturns # Named returns are often helpful, it's naked returns that are the issue
+    - paralleltest # No need here
     - thelper # Lots of false positives due to the way I do table tests in here
     - varnamelen # Lots of false positives of things that are fine
     - wrapcheck # Not every error must be wrapped
@@ -33,6 +34,9 @@ issues:
     - path: _test\.go
       linters:
         - prealloc # These kinds of optimisations will make no difference to test code
+
+  exclude-dirs:
+    - tabwriter # This is 99% a fork of text/tabwriter
 
 linters-settings:
   cyclop:

--- a/hue.go
+++ b/hue.go
@@ -223,7 +223,7 @@ func (s Style) Code() (string, error) { //nolint: cyclop // switch case is signi
 	}
 
 	// Combinations
-	styles := make([]string, 0, numStyles)
+	var c codes
 
 	for style := Bold; style <= BrightWhiteBackground; style <<= 1 {
 		// If the given style has this style bit set, add its code to the string
@@ -233,11 +233,11 @@ func (s Style) Code() (string, error) { //nolint: cyclop // switch case is signi
 				return "", err
 			}
 
-			styles = append(styles, code)
+			c.add(code)
 		}
 	}
 
-	return strings.Join(styles, ";"), nil
+	return c.String(), nil
 }
 
 // Fprint formats using the default formats for its operands and writes to w.
@@ -353,4 +353,59 @@ func autoDetectEnabled() bool {
 
 	// Can't detect otherwise so be safe and disable colour
 	return false
+}
+
+type codes struct {
+	front  [numStyles]string
+	nFront int
+	back   []string
+}
+
+func (c *codes) add(str string) {
+	if c.nFront < len(c.front) {
+		// There's room in the stack buffer
+		c.front[c.nFront] = str
+		c.nFront++
+		return
+	}
+
+	// Slower, we've filled up the stack buffer so must now append
+	// to the back slice
+	c.back = append(c.back, str)
+}
+
+func (c *codes) String() string {
+	var b strings.Builder
+	// Fast path: only the stack buffer is used
+	if len(c.back) == 0 {
+		if c.front[0] != "" {
+			b.WriteString(c.front[0])
+		}
+		for _, code := range c.front[1:] {
+			if code != "" {
+				b.WriteByte(';')
+				b.WriteString(code)
+			}
+		}
+
+		return b.String()
+	}
+
+	// Slower, the codes spilled over to the back slice too
+	if c.front[0] != "" {
+		b.WriteString(c.front[0])
+	}
+	for _, code := range c.front[1:] {
+		if code != "" {
+			b.WriteByte(';')
+			b.WriteString(code)
+		}
+	}
+
+	for _, code := range c.back {
+		b.WriteByte(';')
+		b.WriteString(code)
+	}
+
+	return b.String()
 }

--- a/hue_test.go
+++ b/hue_test.go
@@ -644,6 +644,11 @@ func TestStyleCodeCombinations(t *testing.T) {
 			style: hue.Blue | hue.Red | hue.BlackBackground | hue.Italic | hue.Strikethrough | hue.Bold,
 			want:  "1;3;9;31;34;40",
 		},
+		{
+			name:  "too many styles",
+			style: hue.Blue | hue.Red | hue.BlackBackground | hue.Italic | hue.Strikethrough | hue.Bold | hue.Underline | hue.GreenBackground | hue.Reverse,
+			want:  "1;3;4;7;9;31;34;40;42",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Optimised for the normal case of only a few styles by using the same trick as `log/slog`. Keep a stack allocated array with `n` elements, then any overflow spills over to a `[]string`.

So the fast case (6 styles or less) is ~7% faster, this covers basically all normal usage of the API. Only pathological combinations exceed this. At the cost of the slow case (> 6 styles) being ~18% slower.

This is fine as a trade off because combining more than 6 styles is nonsensical in terms of an actual colour, literally all normal usage will fit into the fast path

```plaintext
goos: darwin
goarch: arm64
pkg: github.com/FollowTheProcess/hue
cpu: Apple M1 Pro
                       │ before.txt  │              after.txt              │
                       │   sec/op    │   sec/op     vs base                │
Style/simple-8           2.332n ± 0%   2.330n ± 0%   -0.09% (p=0.000 n=30)
Style/composite_fast-8   71.13n ± 0%   66.17n ± 0%   -6.98% (p=0.000 n=30)
Style/composite_slow-8   168.2n ± 0%   199.8n ± 0%  +18.79% (p=0.000 n=30)
geomean                  30.33n        31.35n        +3.35%

                       │  before.txt  │              after.txt               │
                       │     B/op     │    B/op     vs base                  │
Style/simple-8           0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=30) ¹
Style/composite_fast-8   16.00 ± 0%     16.00 ± 0%        ~ (p=1.000 n=30) ¹
Style/composite_slow-8   216.0 ± 0%     160.0 ± 0%  -25.93% (p=0.000 n=30)
geomean                             ²                -9.52%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                       │  before.txt  │               after.txt               │
                       │  allocs/op   │ allocs/op   vs base                   │
Style/simple-8           0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=30) ¹
Style/composite_fast-8   1.000 ± 0%     1.000 ± 0%         ~ (p=1.000 n=30) ¹
Style/composite_slow-8   2.000 ± 0%     5.000 ± 0%  +150.00% (p=0.000 n=30)
geomean                             ²                +35.72%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

```
